### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/webview-ui/settings/features.ts
+++ b/webview-ui/settings/features.ts
@@ -73,7 +73,7 @@ export interface Persona {
   builtin?: boolean;
 }
 
-export type ProviderKind = "openai" | "anthropic" | "google" | "openrouter" | "ollama" | "llamacpp";
+export type ProviderKind = "openai" | "anthropic" | "google" | "openrouter" | "astraflow" | "astraflow-cn" | "ollama" | "llamacpp";
 
 export interface ProviderConfig {
   id: string;
@@ -91,12 +91,14 @@ export const PROVIDER_PRESETS: Record<ProviderKind, { label: string; baseUrl: st
   anthropic: { label: "Anthropic", baseUrl: "https://api.anthropic.com/v1", needsKey: true },
   google: { label: "Google Gemini", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", needsKey: true },
   openrouter: { label: "OpenRouter", baseUrl: "https://openrouter.ai/api/v1", needsKey: true },
+  astraflow: { label: "Astraflow (Global)", baseUrl: "https://api-us-ca.umodelverse.ai/v1", needsKey: true },
+  "astraflow-cn": { label: "Astraflow (China)", baseUrl: "https://api.modelverse.cn/v1", needsKey: true },
   ollama: { label: "Ollama", baseUrl: "http://localhost:11434/v1", needsKey: false },
   llamacpp: { label: "llama.cpp", baseUrl: "http://localhost:8080/v1", needsKey: false },
 };
 
 /** Built-in "popular" providers shown as connect-by-key cards. */
-export const POPULAR_KINDS: ProviderKind[] = ["anthropic", "openai", "google", "openrouter"];
+export const POPULAR_KINDS: ProviderKind[] = ["anthropic", "openai", "google", "openrouter", "astraflow", "astraflow-cn"];
 
 export interface ModelOption {
   key: string;


### PR DESCRIPTION
## Changes

Adds Astraflow (by UCloud) as a supported provider in OpenCursor.

### What is Astraflow?
Astraflow is an OpenAI-compatible AI model aggregation platform by UCloud supporting 200+ models, with both global and China endpoints.

### Integration details
- Added two Astraflow presets to `PROVIDER_PRESETS`:
  - **Astraflow (Global)**: `https://api-us-ca.umodelverse.ai/v1` (API key: `ASTRAFLOW_API_KEY`)
  - **Astraflow (China)**: `https://api.modelverse.cn/v1` (API key: `ASTRAFLOW_CN_API_KEY`)
- Added both variants to `POPULAR_KINDS` to show them as quick-connect cards in the Providers panel
- Both use the standard OpenAI-compatible flow (no new SDK or special handling required)

### Testing
Users can now:
1. Open OpenCursor settings → Providers → Popular Providers
2. See Astraflow (Global) and Astraflow (China) cards
3. Connect by entering their API key
4. Select Astraflow models in the chat picker

### References
- Global website: https://astraflow.ucloud-global.com
- China website: https://astraflow.ucloud.cn