### PR TITLE
feat: add Atlas Cloud provider preset

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Ask questions in plain language — *"where do we refresh the auth token?"* — 
 <img src="media/readme/providers.png" alt="Supported providers: OAuth sign-in and API/local providers" width="900"/>
 
 - **OAuth sign-in** — connect your existing **Claude Code**, **OpenAI Codex**, or **Google Antigravity** account and use your subscription's models directly in VS Code.
-- **API keys** — OpenAI, Anthropic, Gemini, OpenRouter presets out of the box.
+- **API keys** — OpenAI, Anthropic, Gemini, OpenRouter, Atlas Cloud presets out of the box.
 - **Custom providers** — add any OpenAI-compatible or Anthropic-style endpoint (base URL + key). Run multiple providers at once; models are fetched live and mixable in the picker.
 - **Auto mode** — a judge model routes each task to the best enabled model. Per-model reasoning effort, thinking mode, and context-size options.
 
@@ -59,7 +59,7 @@ Ask questions in plain language — *"where do we refresh the auth token?"* — 
 2. Open the OpenCursor sidebar and pick a provider:
    - **Local:** one-click llama.cpp install, or point at a running Ollama.
    - **Account:** sign in with Claude Code / OpenAI Codex / Google Antigravity.
-   - **API:** paste a key for OpenAI, Anthropic, Gemini, OpenRouter, or any custom endpoint.
+   - **API:** paste a key for OpenAI, Anthropic, Gemini, OpenRouter, Atlas Cloud, or any custom endpoint.
 3. Start chatting. `Ctrl+L` sends your selection to the chat.
 
 > Native runtime dependencies (ONNX runtime, image processing) are downloaded once on first activation with integrity checks — they're too heavy to ship in the VSIX.

--- a/src/stores/featureStore.ts
+++ b/src/stores/featureStore.ts
@@ -45,7 +45,7 @@ export interface HookDef {
 	enabled: boolean;
 }
 
-export type ProviderKind = "openai" | "anthropic" | "google" | "openrouter" | "ollama" | "llamacpp";
+export type ProviderKind = "openai" | "anthropic" | "google" | "openrouter" | "atlascloud" | "ollama" | "llamacpp";
 
 /** Where a model can be served from: API provider kinds + OAuth account kinds. */
 export type ModelKind = ProviderKind | "claude-code" | "codex" | "antigravity";
@@ -272,6 +272,7 @@ export const PROVIDER_PRESETS: Record<ProviderKind, { label: string; baseUrl: st
 	anthropic: { label: "Anthropic", baseUrl: "https://api.anthropic.com/v1", needsKey: true },
 	google: { label: "Google Gemini", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", needsKey: true },
 	openrouter: { label: "OpenRouter", baseUrl: "https://openrouter.ai/api/v1", needsKey: true },
+	atlascloud: { label: "Atlas Cloud", baseUrl: "https://api.atlascloud.ai/v1", needsKey: true },
 	ollama: { label: "Ollama", baseUrl: "http://localhost:11434/v1", needsKey: false },
 	llamacpp: { label: "llama.cpp", baseUrl: "http://localhost:8080/v1", needsKey: false },
 };

--- a/webview-ui/settings/features.ts
+++ b/webview-ui/settings/features.ts
@@ -73,7 +73,7 @@ export interface Persona {
   builtin?: boolean;
 }
 
-export type ProviderKind = "openai" | "anthropic" | "google" | "openrouter" | "ollama" | "llamacpp";
+export type ProviderKind = "openai" | "anthropic" | "google" | "openrouter" | "atlascloud" | "ollama" | "llamacpp";
 
 export interface ProviderConfig {
   id: string;
@@ -91,12 +91,13 @@ export const PROVIDER_PRESETS: Record<ProviderKind, { label: string; baseUrl: st
   anthropic: { label: "Anthropic", baseUrl: "https://api.anthropic.com/v1", needsKey: true },
   google: { label: "Google Gemini", baseUrl: "https://generativelanguage.googleapis.com/v1beta/openai", needsKey: true },
   openrouter: { label: "OpenRouter", baseUrl: "https://openrouter.ai/api/v1", needsKey: true },
+  atlascloud: { label: "Atlas Cloud", baseUrl: "https://api.atlascloud.ai/v1", needsKey: true },
   ollama: { label: "Ollama", baseUrl: "http://localhost:11434/v1", needsKey: false },
   llamacpp: { label: "llama.cpp", baseUrl: "http://localhost:8080/v1", needsKey: false },
 };
 
 /** Built-in "popular" providers shown as connect-by-key cards. */
-export const POPULAR_KINDS: ProviderKind[] = ["anthropic", "openai", "google", "openrouter"];
+export const POPULAR_KINDS: ProviderKind[] = ["anthropic", "openai", "google", "openrouter", "atlascloud"];
 
 export interface ModelOption {
   key: string;


### PR DESCRIPTION
## Summary
- Add Atlas Cloud as a built-in API provider preset
- Surface Atlas Cloud in the Popular Providers setup flow
- Document the Atlas Cloud API-key preset alongside the existing hosted providers

## Validation
- pnpm install --frozen-lockfile
- pnpm run check-types
- pnpm run lint
- pnpm run package

## Notes
- Uses the existing OpenAI-compatible provider flow and live model discovery
- No sponsor block, logo, credits, partner copy, or default model behavior change